### PR TITLE
it would be great if Timeout property will be implemented.

### DIFF
--- a/src/MvcContrib.TestHelper/MvcContrib.TestHelper/MockSession.cs
+++ b/src/MvcContrib.TestHelper/MvcContrib.TestHelper/MockSession.cs
@@ -9,7 +9,7 @@ namespace MvcContrib.TestHelper
 	internal class MockSession : HttpSessionStateBase
 	{
 		private readonly IDictionary _objects;
-
+	        private int _timeout;
 		/// <summary>
 		/// Initializes a new instance of the <see cref="MockSession"/> class.
 		/// </summary>
@@ -187,8 +187,8 @@ namespace MvcContrib.TestHelper
 		/// </summary>
 		public override int Timeout
 		{
-			get { throw new NotImplementedException(); }
-			set { throw new NotImplementedException(); }
+		 	get { return _timeout; }
+			set { _timeout = value; }
 		}
 
 		/// <summary>


### PR DESCRIPTION
we are using moq for test driven development. and in application, session.tiomeout is configurable (while user login). 
As here, timeout is not implemented, nothing is working as user is not able login while executing the testcases.
               private int _timeout;
		public override int Timeout
		{
			get { return _timeout;}
			set {  _timeout = value;}
		}